### PR TITLE
Bump main to next pre-release after stable release

### DIFF
--- a/.github/badges/coverage.svg
+++ b/.github/badges/coverage.svg
@@ -17,7 +17,7 @@
         <text x="32.5" y="14">coverage</text>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-        <text x="92.5" y="15" fill="#010101" fill-opacity=".3">64.78%</text>
-        <text x="91.5" y="14">64.78%</text>
+        <text x="92.5" y="15" fill="#010101" fill-opacity=".3">78.69%</text>
+        <text x="91.5" y="14">78.69%</text>
     </g>
 </svg>

--- a/.github/badges/coverage.svg
+++ b/.github/badges/coverage.svg
@@ -17,7 +17,7 @@
         <text x="32.5" y="14">coverage</text>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-        <text x="92.5" y="15" fill="#010101" fill-opacity=".3">78.69%</text>
-        <text x="91.5" y="14">78.69%</text>
+        <text x="92.5" y="15" fill="#010101" fill-opacity=".3">64.78%</text>
+        <text x="91.5" y="14">64.78%</text>
     </g>
 </svg>

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -39,6 +39,7 @@ jobs:
             echo "triggered_by=tag" >> $GITHUB_OUTPUT
           else
             echo "triggered_by=branch" >> $GITHUB_OUTPUT
+          fi
 
       - name: Get latest tag from history
         if: steps.trigger.outputs.triggered_by == 'branch'

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -59,7 +59,9 @@ jobs:
           MAJOR=$(echo "$VERSION" | cut -d . -f 1)
           MINOR=$(echo "$VERSION" | cut -d . -f 2)
           PATCH=$(echo "$VERSION" | cut -d . -f 3)
-          PATCH=$((PATCH + 1))
+          if [[ "${{ steps.trigger.outputs.triggered_by }}" == "tag" ]]; then
+            PATCH=$((PATCH + 1))
+          fi
           DATETIME=$(date +%Y%m%d.%H%M%S)
           NEW_VERSION="$MAJOR.$MINOR.$PATCH-pre.$DATETIME"
           echo "version=$NEW_VERSION"  >> $GITHUB_ENV

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -7,10 +7,8 @@ on:
     tags-ignore:
       - '**'
   
-  workflow_run:
-    workflows: ["Release"]
-    types:
-      - completed
+  repository_dispatch:
+    types: [trigger-pre-release]
 
 env:
   PYTHON_VERSION: '3.12.3'
@@ -41,7 +39,7 @@ jobs:
       - name: Determine trigger type
         id: trigger
         run: |
-          if [ "${{ github.event_name }}" == "workflow_run" ] && [ "${{ github.event.workflow }}" == "Release" ]; then
+          if [ "${{ github.event_name }}" == "repository_dispatch" ]; then
             echo "triggered_by=release" >> $GITHUB_OUTPUT
           else
             echo "triggered_by=push" >> $GITHUB_OUTPUT
@@ -51,10 +49,10 @@ jobs:
           LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
           echo "latest_tag=$LATEST_TAG" >> $GITHUB_ENV
       
-      - name: Parse version from tag (if triggered by tag)
+      - name: Parse version from latest tag (if triggered by release)
         if: steps.trigger.outputs.triggered_by == 'release'
         run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
+          VERSION=${latest_tag#v}
           echo "version=$VERSION" >> $GITHUB_ENV
 
       - name: Calculate pre-release version

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
         main
-    tags-ignore:
-      - '**'
+    tags:
+      - 'v*-pre.*'
 
 env:
   PYTHON_VERSION: '3.12.3'
@@ -33,12 +33,27 @@ jobs:
           python -m pip install --upgrade pip
           pip install .
 
+      - name: Determine trigger type
+        id: trig
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "triggered_by=tag" >> $GITHUB_OUTPUT
+          else
+            echo "triggered_by=branch" >> $GITHUB_OUTPUT
+
       - name: Get latest tag
         run: |
           LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
           echo "latest_tag=$LATEST_TAG" >> $GITHUB_ENV
+      
+      - name: Parse version from tag (if triggered by tag)
+        if: steps.trig.outputs.triggered_by == 'tag'
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "version=$VERSION" >> $GITHUB_ENV
 
       - name: Calculate pre-release version
+        if: steps.trig.outputs.triggered_by == 'branch'
         run: |
           VERSION=${latest_tag#v}
           MAJOR=$(echo "$VERSION" | cut -d . -f 1)
@@ -59,6 +74,7 @@ jobs:
         run: python model-training/restaurant_sentiment/train.py
 
       - name: Tag pre-release commit
+        if: steps.trig.outputs.triggered_by == 'branch'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -4,11 +4,7 @@ on:
   push:
     branches:
         main
-    tags-ignore:
-      - '**'
-  
-  repository_dispatch:
-    types: [trigger-pre-release]
+    tags: ["v[0-9]+.[0-9]+.[0-9]+"]
 
 env:
   PYTHON_VERSION: '3.12.3'
@@ -39,24 +35,24 @@ jobs:
       - name: Determine trigger type
         id: trigger
         run: |
-          if [ "${{ github.event_name }}" == "repository_dispatch" ]; then
-            echo "triggered_by=release" >> $GITHUB_OUTPUT
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            echo "triggered_by=tag" >> $GITHUB_OUTPUT
           else
-            echo "triggered_by=push" >> $GITHUB_OUTPUT
+            echo "triggered_by=branch" >> $GITHUB_OUTPUT
 
-      - name: Get latest tag
+      - name: Get latest tag from history
+        if: steps.trigger.outputs.triggered_by == 'branch'
         run: |
           LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
           echo "latest_tag=$LATEST_TAG" >> $GITHUB_ENV
-      
-      - name: Parse version from latest tag (if triggered by release)
-        if: steps.trigger.outputs.triggered_by == 'release'
+
+      - name: Get latest tag from pushed tag
+        if: steps.trigger.outputs.triggered_by == 'tag'
         run: |
-          VERSION=${latest_tag#v}
-          echo "version=$VERSION" >> $GITHUB_ENV
+          LATEST_TAG=${GITHUB_REF:11}
+          echo "latest_tag=$LATEST_TAG" >> $GITHUB_ENV
 
       - name: Calculate pre-release version
-        if: steps.trigger.outputs.triggered_by == 'push'
         run: |
           VERSION=${latest_tag#v}
           MAJOR=$(echo "$VERSION" | cut -d . -f 1)
@@ -77,11 +73,12 @@ jobs:
         run: python model-training/restaurant_sentiment/train.py
 
       - name: Tag pre-release commit
-        if: steps.trigger.outputs.triggered_by == 'push'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag v${{ env.version }}
+          git fetch origin main
+          MAIN_SHA=$(git rev-parse origin/main)
+          git tag v${{ env.version }} $MAIN_SHA
           git push origin v${{ env.version }}
 
       - name: Create GitHub pre-release

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -4,8 +4,13 @@ on:
   push:
     branches:
         main
-    tags:
-      - 'v*-pre.*'
+    tags-ignore:
+      - '**'
+  
+  workflow_run:
+    workflows: ["Release"]
+    types:
+      - completed
 
 env:
   PYTHON_VERSION: '3.12.3'
@@ -34,12 +39,12 @@ jobs:
           pip install .
 
       - name: Determine trigger type
-        id: trig
+        id: trigger
         run: |
-          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            echo "triggered_by=tag" >> $GITHUB_OUTPUT
+          if [ "${{ github.event_name }}" == "workflow_run" ] && [ "${{ github.event.workflow }}" == "Release" ]; then
+            echo "triggered_by=release" >> $GITHUB_OUTPUT
           else
-            echo "triggered_by=branch" >> $GITHUB_OUTPUT
+            echo "triggered_by=push" >> $GITHUB_OUTPUT
 
       - name: Get latest tag
         run: |
@@ -47,13 +52,13 @@ jobs:
           echo "latest_tag=$LATEST_TAG" >> $GITHUB_ENV
       
       - name: Parse version from tag (if triggered by tag)
-        if: steps.trig.outputs.triggered_by == 'tag'
+        if: steps.trigger.outputs.triggered_by == 'release'
         run: |
           VERSION=${GITHUB_REF#refs/tags/v}
           echo "version=$VERSION" >> $GITHUB_ENV
 
       - name: Calculate pre-release version
-        if: steps.trig.outputs.triggered_by == 'branch'
+        if: steps.trigger.outputs.triggered_by == 'push'
         run: |
           VERSION=${latest_tag#v}
           MAJOR=$(echo "$VERSION" | cut -d . -f 1)
@@ -74,7 +79,7 @@ jobs:
         run: python model-training/restaurant_sentiment/train.py
 
       - name: Tag pre-release commit
-        if: steps.trig.outputs.triggered_by == 'branch'
+        if: steps.trigger.outputs.triggered_by == 'push'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
         main
+    tags-ignore:
+      - '**'
 
 env:
   PYTHON_VERSION: '3.12.3'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,29 +59,3 @@ jobs:
           file: model/model.pkl
           asset_name: model-v${{ env.version }}.pkl
           tag: v${{ env.version }}
-      
-      - name: Calculate pre-release version
-        run: |
-          VERSION=${version}
-          MAJOR=$(echo "$VERSION" | cut -d . -f 1)
-          MINOR=$(echo "$VERSION" | cut -d . -f 2)
-          PATCH=$(echo "$VERSION" | cut -d . -f 3)
-          PATCH=$((PATCH + 1))
-          DATETIME=$(date +%Y%m%d.%H%M%S)
-          PRE_RELEASE_VERSION="$MAJOR.$MINOR.$PATCH-pre.$DATETIME"
-          echo "pre_release_version=$PRE_RELEASE_VERSION"  >> $GITHUB_ENV
-
-      - name: Tag next pre-release version on main
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin main
-          git checkout main
-          git tag v${{ env.pre_release_version }}
-          git push origin v${{ env.pre_release_version }}
-
-      - name: Trigger pre-release workflow
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          event-type: trigger-pre-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           tag_name: v${{ env.version }}
+          generate_release_notes: true
 
       - name: Upload BoW vectorizer model
         uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,3 +59,21 @@ jobs:
           file: model/model.pkl
           asset_name: model-v${{ env.version }}.pkl
           tag: v${{ env.version }}
+      
+      - name: Calculate pre-release version
+        run: |
+          VERSION=${version}
+          MAJOR=$(echo "$VERSION" | cut -d . -f 1)
+          MINOR=$(echo "$VERSION" | cut -d . -f 2)
+          PATCH=$(echo "$VERSION" | cut -d . -f 3)
+          PATCH=$((PATCH + 1))
+          DATETIME=$(date +%Y%m%d.%H%M%S)
+          PRE_RELEASE_VERSION="$MAJOR.$MINOR.$PATCH-pre.$DATETIME"
+          echo "pre_release_version=$PRE_RELEASE_VERSION"  >> $GITHUB_ENV
+
+      - name: Tag next pre-release version on main
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag v${{ env.pre_release_version }}
+          git push origin v${{ env.pre_release_version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,5 +75,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin main
+          git checkout main
           git tag v${{ env.pre_release_version }}
           git push origin v${{ env.pre_release_version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,3 +79,9 @@ jobs:
           git checkout main
           git tag v${{ env.pre_release_version }}
           git push origin v${{ env.pre_release_version }}
+
+      - name: Trigger pre-release workflow
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          event-type: trigger-pre-release

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,6 +1,9 @@
 name: Test and Quality metrics
 
-on: [push]
+on:
+  push:
+    branches:
+      - '**' 
 
 jobs:
   run-and-collect-tests:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - '**' 
+    tags-ignore:
+      - '**'
 
 jobs:
   run-and-collect-tests:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,7 +2,7 @@ joblib==1.4.2
 pandas==2.2.3
 scikit-learn==1.6.1
 requests==2.32.3
-git+https://github.com/remla25-team6/lib-ml.git@v0.1.0
+git+https://github.com/remla25-team6/lib-ml.git@v0.2.0
 
 # Extra non-production requirements
 jupyter==1.1.1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,7 +2,7 @@ joblib==1.4.2
 pandas==2.2.3
 scikit-learn==1.6.1
 requests==2.32.3
-git+https://github.com/remla25-team6/lib-ml.git
+git+https://github.com/remla25-team6/lib-ml.git@v0.1.0
 
 # Extra non-production requirements
 jupyter==1.1.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "pandas==2.2.3",
     "scikit-learn==1.6.1",
     "requests==2.32.3",
-    "lib-ml @ git+https://github.com/remla25-team6/lib-ml.git@v0.1.0"
+    "lib-ml @ git+https://github.com/remla25-team6/lib-ml.git@v0.2.0"
 ]
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "pandas==2.2.3",
     "scikit-learn==1.6.1",
     "requests==2.32.3",
-    "lib-ml @ git+https://github.com/remla25-team6/lib-ml.git"
+    "lib-ml @ git+https://github.com/remla25-team6/lib-ml.git@v0.1.0"
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
This PR addresses the criteria from **A1** for **Versioning & Releases**"
- After a stable release, main is set to a pre-release version that is higher than the latest release.

Addresses issue: https://github.com/remla25-team6/operation/issues/1