### PR TITLE
Implement mutamorphic testing with automatic inconsistency repair

### DIFF
--- a/.github/badges/coverage.svg
+++ b/.github/badges/coverage.svg
@@ -17,7 +17,7 @@
         <text x="32.5" y="14">coverage</text>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-        <text x="92.5" y="15" fill="#010101" fill-opacity=".3">81.82%</text>
-        <text x="91.5" y="14">81.82%</text>
+        <text x="92.5" y="15" fill="#010101" fill-opacity=".3">81.05%</text>
+        <text x="91.5" y="14">81.05%</text>
     </g>
 </svg>

--- a/.github/badges/coverage.svg
+++ b/.github/badges/coverage.svg
@@ -17,7 +17,7 @@
         <text x="32.5" y="14">coverage</text>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-        <text x="92.5" y="15" fill="#010101" fill-opacity=".3">81.76%</text>
-        <text x="91.5" y="14">81.76%</text>
+        <text x="92.5" y="15" fill="#010101" fill-opacity=".3">81.82%</text>
+        <text x="91.5" y="14">81.82%</text>
     </g>
 </svg>

--- a/.github/badges/pylint.svg
+++ b/.github/badges/pylint.svg
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="87" height="20">
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="20">
     <linearGradient id="b" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
     </linearGradient>
     <mask id="anybadge_1">
-        <rect width="87" height="20" rx="3" fill="#fff"/>
+        <rect width="80" height="20" rx="3" fill="#fff"/>
     </mask>
     <g mask="url(#anybadge_1)">
         <path fill="#555" d="M0 0h44v20H0z"/>
-        <path fill="#4c1" d="M44 0h43v20H44z"/>
-        <path fill="url(#b)" d="M0 0h87v20H0z"/>
+        <path fill="#4C1" d="M44 0h36v20H44z"/>
+        <path fill="url(#b)" d="M0 0h80v20H0z"/>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="23.0" y="15" fill="#010101" fill-opacity=".3">pylint</text>
         <text x="22.0" y="14">pylint</text>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-        <text x="66.5" y="15" fill="#010101" fill-opacity=".3">10/10</text>
-        <text x="65.5" y="14">10/10</text>
+        <text x="63.0" y="15" fill="#010101" fill-opacity=".3">9/10</text>
+        <text x="62.0" y="14">9/10</text>
     </g>
 </svg>

--- a/.github/badges/pylint.svg
+++ b/.github/badges/pylint.svg
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="80" height="20">
+<svg xmlns="http://www.w3.org/2000/svg" width="87" height="20">
     <linearGradient id="b" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
     </linearGradient>
     <mask id="anybadge_1">
-        <rect width="80" height="20" rx="3" fill="#fff"/>
+        <rect width="87" height="20" rx="3" fill="#fff"/>
     </mask>
     <g mask="url(#anybadge_1)">
         <path fill="#555" d="M0 0h44v20H0z"/>
-        <path fill="#4C1" d="M44 0h36v20H44z"/>
-        <path fill="url(#b)" d="M0 0h80v20H0z"/>
+        <path fill="#4c1" d="M44 0h43v20H44z"/>
+        <path fill="url(#b)" d="M0 0h87v20H0z"/>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="23.0" y="15" fill="#010101" fill-opacity=".3">pylint</text>
         <text x="22.0" y="14">pylint</text>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-        <text x="63.0" y="15" fill="#010101" fill-opacity=".3">9/10</text>
-        <text x="62.0" y="14">9/10</text>
+        <text x="66.5" y="15" fill="#010101" fill-opacity=".3">10/10</text>
+        <text x="65.5" y="14">10/10</text>
     </g>
 </svg>

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Run tests with coverage
       id: pytest
       run: |
-        pytest --cov=. --cov-report=xml --cov-report=term --cov-report=html --junit-xml=pytest-report.xml || true
+        pytest --cov=. --cov-report=xml --cov-report=term --cov-report=html --junit-xml=pytest-report.xml
         
         COVERAGE=$(python -c "import xml.etree.ElementTree as ET; tree = ET.parse('coverage.xml'); root = tree.getroot(); print(round(float(root.attrib['line-rate']) * 100, 2))")
         echo "COVERAGE=$COVERAGE" >> $GITHUB_ENV

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The training pipeline performs the following steps:
 1. Downloads the dataset in `.tsv` from the sentiment-analysis repo in `get_data.py`.
 2. Loads the labelled dataset in `.tsv` format containing restaurant reviews.
 3. Preprocesses the data using methods from the `lib-ml` package in `preprocess.py`.
-4. Trains a Naive Bayes classifier in `train.py`.
+4. Trains a SVC classifier in `train.py`.
 5. Saves the trained model locally to `model/model.pkl`.
 6. Evaluates the trained model in `eval.py`.
 7. Publishes a versioned model artifact to **GitHub Releases**.

--- a/dvc.lock
+++ b/dvc.lock
@@ -5,8 +5,8 @@ stages:
     deps:
     - path: model-training/restaurant_sentiment/get_data.py
       hash: md5
-      md5: c66fdc0bef3b5f99bcea4ab58a87d81b
-      size: 1109
+      md5: 6f0157716c4d9b1b1234173b17f82f71
+      size: 1116
     outs:
     - path: data/RestaurantReviews_HistoricDump.tsv
       hash: md5
@@ -21,8 +21,8 @@ stages:
       size: 54686
     - path: model-training/restaurant_sentiment/preprocess.py
       hash: md5
-      md5: 53f8f0392e5625ab26dfe77b3ce6bbdc
-      size: 1934
+      md5: b993d9a767af06b0cbec5b4dfc30f6d6
+      size: 2119
     outs:
     - path: data/corpus.pkl
       hash: md5
@@ -45,54 +45,54 @@ stages:
       size: 7425
     - path: model-training/restaurant_sentiment/train.py
       hash: md5
-      md5: 6b33f5c4d4c34bfb8559e9491fe0a3f0
-      size: 2491
+      md5: a697aff7e08ac89611100a030cd570fc
+      size: 3762
     outs:
     - path: data/X_test.pkl
       hash: md5
-      md5: 6cb500da31cb15a3cd315bfc5ac9d834
-      size: 2045041
+      md5: ce3aca7e4a2e7be870c99dd913f42cd6
+      size: 2056401
     - path: data/X_train.pkl
       hash: md5
-      md5: 9f022364885be5b6071e274b3a441dc5
-      size: 8179441
+      md5: 50fb3b3827ebef86b96dfead4a5b65a1
+      size: 8213521
     - path: data/y_test.pkl
       hash: md5
-      md5: 2206173e02946f0a2594ab9f80fd8f50
-      size: 1665
+      md5: ccb4faa62eb5d61420109c2a30429417
+      size: 1673
     - path: data/y_train.pkl
       hash: md5
-      md5: 06bd601c1b0d30379a423b5c9bd03bf1
-      size: 5985
+      md5: cc08030850b294e30ff507a881872051
+      size: 6009
     - path: model/bow.pkl
       hash: md5
-      md5: 3fad7a4c0ec1b2a1fc95334240b40d81
-      size: 39432
+      md5: 5ccc5235616fb00f006b91057f8d07ef
+      size: 39415
     - path: model/model.pkl
       hash: md5
-      md5: 7dc6aed243ae2e83d0af2e966804ad5f
-      size: 46215
+      md5: f47830cb611050c3f0871305afd16a8e
+      size: 4080969
   evaluate:
     cmd: python model-training/restaurant_sentiment/eval.py
     deps:
     - path: data/X_test.pkl
       hash: md5
-      md5: 6cb500da31cb15a3cd315bfc5ac9d834
-      size: 2045041
+      md5: ce3aca7e4a2e7be870c99dd913f42cd6
+      size: 2056401
     - path: data/y_test.pkl
       hash: md5
-      md5: 2206173e02946f0a2594ab9f80fd8f50
-      size: 1665
+      md5: ccb4faa62eb5d61420109c2a30429417
+      size: 1673
     - path: model-training/restaurant_sentiment/eval.py
       hash: md5
-      md5: e1faca072371bbca0f6b9c6c72661dd5
-      size: 1949
+      md5: 26bfb4da12f521a7e47407ddac2b565e
+      size: 1875
     - path: model/model.pkl
       hash: md5
-      md5: 7dc6aed243ae2e83d0af2e966804ad5f
-      size: 46215
+      md5: f47830cb611050c3f0871305afd16a8e
+      size: 4080969
     outs:
     - path: model/metrics.json
       hash: md5
-      md5: 601628fbf6ab87a059c823ef9e0038ce
-      size: 372
+      md5: 10beffa978830043eff5d155bc33f9ca
+      size: 370

--- a/dvc.lock
+++ b/dvc.lock
@@ -45,8 +45,8 @@ stages:
       size: 7425
     - path: model-training/restaurant_sentiment/train.py
       hash: md5
-      md5: a697aff7e08ac89611100a030cd570fc
-      size: 3762
+      md5: 1d00e4e4b3680b9fdfdfa5e8ec83aa44
+      size: 3672
     outs:
     - path: data/X_test.pkl
       hash: md5
@@ -70,8 +70,8 @@ stages:
       size: 39415
     - path: model/model.pkl
       hash: md5
-      md5: f47830cb611050c3f0871305afd16a8e
-      size: 4080969
+      md5: 50deff1f2463f1a50f303feb1f4e0773
+      size: 7375883
   evaluate:
     cmd: python model-training/restaurant_sentiment/eval.py
     deps:
@@ -89,10 +89,10 @@ stages:
       size: 1875
     - path: model/model.pkl
       hash: md5
-      md5: f47830cb611050c3f0871305afd16a8e
-      size: 4080969
+      md5: 50deff1f2463f1a50f303feb1f4e0773
+      size: 7375883
     outs:
     - path: model/metrics.json
       hash: md5
-      md5: 10beffa978830043eff5d155bc33f9ca
+      md5: b723485f882d41d43e45eb677286bed7
       size: 370

--- a/model-training/restaurant_sentiment/eval.py
+++ b/model-training/restaurant_sentiment/eval.py
@@ -42,8 +42,6 @@ def evaluate(data_path="data", model_path="model"):
     # Dump to json
     with open(os.path.join(model_path, "metrics.json"), "w") as f:
         json.dump(metrics, f, indent=4)
-    
-    # Output to console
     print("Confusion Matrix:")
     print(cm)
     print(f"Accuracy: {acc}")

--- a/model-training/restaurant_sentiment/train.py
+++ b/model-training/restaurant_sentiment/train.py
@@ -8,7 +8,7 @@ from joblib import load, dump
 
 from sklearn.feature_extraction.text import CountVectorizer
 from sklearn.model_selection import train_test_split
-from sklearn.ensemble import RandomForestClassifier
+from sklearn.svm import SVC
 
 
 def train(
@@ -48,9 +48,9 @@ def train(
         X, y, test_size=test_size, random_state=random_state
     )
 
-    # Train the Gaussian Naive Bayes classifier
-    print("Training Naive Bayes classifier...")
-    model = RandomForestClassifier()
+    # Train the SVC
+    print("Training SVC...")
+    model = SVC()
     model.fit(X_train, y_train)
 
     # Create 'model' directory if it does not exist

--- a/model-training/tests/test_feature_data.py
+++ b/model-training/tests/test_feature_data.py
@@ -1,27 +1,17 @@
+import os
 import pytest
 import pandas as pd
-import os
 from sklearn.metrics import accuracy_score
 from joblib import load
 
 from restaurant_sentiment.preprocess import load_and_preprocess_data
 from restaurant_sentiment.train import train
-from restaurant_sentiment.get_data import download_dataset
-from restaurant_sentiment.preprocess import main
+from tests.utils import load_sample_data
 
 
 @pytest.fixture
 def load_data(tmp_path):
-    url = "https://raw.githubusercontent.com/proksch/restaurant-sentiment/" \
-    "main/a1_RestaurantReviews_HistoricDump.tsv"
-    download_dataset(
-        url, os.path.join(tmp_path, "data/RestaurantReviews_HistoricDump.tsv")
-    )
-    main(
-        data_path=os.path.join(tmp_path, "data"),
-        filepath=os.path.join(tmp_path, "data/RestaurantReviews_HistoricDump.tsv"),
-    )
-    return tmp_path
+    return load_sample_data(tmp_path)
 
 @pytest.fixture
 def sample_data(tmp_path):
@@ -46,8 +36,10 @@ def test_data_2_stopword_removal(sample_data):
 
 def test_data_3_cost_features(load_data):
     # The cost of features is being tested.
-    # This test justifies using the number of features we use. If using less features results in better performance,
-    # measured by a 10% increase in performance for statistical significance, then this test case fails.
+    # This test justifies using the number of features we use.
+    # If using less features results in better performance,
+    # measured by a 10% increase in performance for statistical significance,
+    # then this test case fails.
     tmp_path = load_data
     max_feature_opts = [1000, 1420]
     accuracies = []
@@ -67,5 +59,8 @@ def test_data_3_cost_features(load_data):
         accuracies.append(accuracy)
 
     assert (
-            accuracies[0] / accuracies[1] < 1.1
-    ), f"Accuracy with {max_feature_opts[0]} features is more than 10% larger than with {max_feature_opts[1]} features."
+        accuracies[0] / accuracies[1] < 1.1
+    ), (
+        f"Accuracy with {max_feature_opts[0]} features is more than "
+        f"10% larger than with {max_feature_opts[1]} features."
+    )

--- a/model-training/tests/test_mutamorphic.py
+++ b/model-training/tests/test_mutamorphic.py
@@ -62,8 +62,6 @@ def test_model_1_synonym_invariance(load_data):
             f"'{s1}' → {pred1}, '{s2}' → {pred2}"
         )
 
-        assert 1 == 2
-
 
 def test_model_2_feature_swap_stability(load_data):
     # Swapping BoW features should not change prediction

--- a/model-training/tests/test_mutamorphic.py
+++ b/model-training/tests/test_mutamorphic.py
@@ -1,0 +1,103 @@
+import os
+import pytest
+import joblib
+import numpy as np
+import pandas as pd
+from tests.utils import load_sample_data
+from restaurant_sentiment.train import train
+
+REPAIR_PATH = "data/repair_dataset.tsv"
+
+@pytest.fixture
+def load_data(tmp_path):
+    return load_sample_data(tmp_path)
+
+def append_to_repair_file(text, label):
+    """
+    Append a single (text, label) pair to the repair dataset. 
+    This allows failed metamorphic test cases to be captured for future retraining
+    for automatic inconsistency repair.
+    """
+    # Used ChatGPT 4o to append data to repair files
+    os.makedirs(os.path.dirname(REPAIR_PATH), exist_ok=True)
+    row = pd.DataFrame([[text, label]], columns=["Review", "Sentiment"])
+    row.to_csv(
+        REPAIR_PATH,
+        sep="\t",
+        index=False,
+        mode="a",
+        header=not os.path.exists(REPAIR_PATH))
+
+def test_model_1_synonym_invariance(load_data):
+    # Synonymous inputs should result in same prediction
+    tmp_path = load_data
+    model_path = os.path.join(tmp_path, "model")
+    data_path = os.path.join(tmp_path, "data")
+
+    train(data_path=data_path, model_path=model_path)
+
+    model = joblib.load(os.path.join(model_path, "model.pkl"))
+    bow = joblib.load(os.path.join(model_path, "bow.pkl"))
+
+    synonym_pairs = [
+        ("The food was great", "The food was good"),
+        ("The people were horrible", "The people were terrible"),
+        ("I liked the game", "I loved the game"),
+        ("This house is bad", "This house is gross"),
+    ]
+
+    for s1, s2 in synonym_pairs:
+        x1 = bow.transform([s1]).toarray()
+        x2 = bow.transform([s2]).toarray()
+        pred1 = model.predict(x1)[0]
+        pred2 = model.predict(x2)[0]
+
+        if pred1 != pred2:
+            # Save variants to repair file for automatic inconsistency repair
+            append_to_repair_file(s1, pred1)
+            append_to_repair_file(s2, pred1)
+
+        assert pred1 == pred2, (
+            f"Model gave different predictions for synonyms:\n"
+            f"'{s1}' → {pred1}, '{s2}' → {pred2}"
+        )
+
+
+def test_model_2_feature_swap_stability(load_data):
+    # Swapping BoW features should not change prediction
+    # Used ChatGPT 4o to solve how to swap features
+    tmp_path = load_data
+    model_path = os.path.join(tmp_path, "model")
+    data_path = os.path.join(tmp_path, "data")
+
+    train(data_path=data_path, model_path=model_path)
+
+    model = joblib.load(os.path.join(model_path, "model.pkl"))
+    bow = joblib.load(os.path.join(model_path, "bow.pkl"))
+
+    test_texts = [
+        "Absolutely loved the food and service.",
+        "This place was terrible, not going back.",
+        "Great drinks, fun atmosphere.",
+        "Worst customer service I’ve had in years.",
+    ]
+
+    rng = np.random.default_rng(42)
+
+    for text in test_texts:
+        vec = bow.transform([text]).toarray()
+        i, j = rng.integers(0, vec.shape[1], size=2)
+        vec_swapped = vec.copy()
+        vec_swapped[0, i], vec_swapped[0, j] = vec_swapped[0, j], vec_swapped[0, i]
+
+        pred_original = model.predict(vec)[0]
+        pred_swapped = model.predict(vec_swapped)[0]
+
+        if pred_original != pred_swapped:
+            # Assuming original predction is correct, add for retraining
+            append_to_repair_file(text, pred_original)
+
+        assert pred_original == pred_swapped, (
+            f"Prediction changed after swapping feature indices {i} and {j} "
+            f"in input: '{text}'\nOriginal → {pred_original}, Swapped → {pred_swapped}"
+        )

--- a/model-training/tests/test_mutamorphic.py
+++ b/model-training/tests/test_mutamorphic.py
@@ -62,6 +62,8 @@ def test_model_1_synonym_invariance(load_data):
             f"'{s1}' → {pred1}, '{s2}' → {pred2}"
         )
 
+        assert 1 == 2
+
 
 def test_model_2_feature_swap_stability(load_data):
     # Swapping BoW features should not change prediction

--- a/model-training/tests/utils.py
+++ b/model-training/tests/utils.py
@@ -1,0 +1,16 @@
+import os
+from restaurant_sentiment.get_data import download_dataset
+from restaurant_sentiment.preprocess import main
+
+def load_sample_data(tmp_path):
+    url = (
+        "https://raw.githubusercontent.com/proksch/restaurant-sentiment/"
+        "main/a1_RestaurantReviews_HistoricDump.tsv"
+    )
+    dataset_path = os.path.join(tmp_path, "data/RestaurantReviews_HistoricDump.tsv")
+    download_dataset(url, dataset_path)
+    main(
+        data_path=os.path.join(tmp_path, "data"),
+        filepath=dataset_path,
+    )
+    return tmp_path


### PR DESCRIPTION
This PR closes the following issue: https://github.com/remla25-team6/operation/issues/57

- Implements mutamorphic testing through synonym invariance feature order invariance tests
- Implements automatic inconsistency repair by saving failing test data to a repair dataset, which is included upon re-training
- Fixes remaining linter warnings